### PR TITLE
Add parsing and checking of requires and tool_requires from requirements method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,21 @@
 repos:
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: end-of-file-fixer
         exclude: ^tests/output/
       - id: trailing-whitespace
         exclude: ^tests/output/
   - repo: "https://github.com/psf/black"
-    rev: 22.12.0
+    rev: 24.3.0
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.258
+    rev: v0.3.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: "https://github.com/pre-commit/mirrors-mypy"
-    rev: v0.991
+    rev: v1.9.0
     hooks:
       - id: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ line-length = 100
 
 [tool.ruff]
 line-length = 100
-select = [
+lint.select = [
     "F", # pyflakes
     "E", "W", # pycodestyle
     "I", # isort
@@ -87,11 +87,11 @@ select = [
     "PL", # pylint
     "RUF", # ruff specific rules
 ]
-ignore = [
+lint.ignore = [
     "PLR0911", # too many return statements
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = [
     "PLR0913", # too many arguments
     "PLR2004", # magic value
@@ -125,7 +125,7 @@ envlist =
     black
     ruff
     mypy
-    py{37, 38, 39, 310, 311}-{v1, v2}
+    py{37, 38, 39, 310, 311, 312}-{v1, v2}
     coverage-report
 
 [testenv:black]

--- a/src/conan_check_updates/color.py
+++ b/src/conan_check_updates/color.py
@@ -61,7 +61,7 @@ class AnsiCodes(IntEnum):
     BG_DEFAULT = 49
 
     def __str__(self) -> str:
-        return f"\033[{str(self.value)}m"
+        return f"\033[{self.value!s}m"
 
 
 def colored(text: str, *codes: AnsiCodes, force_color: bool = False) -> str:

--- a/src/conan_check_updates/main.py
+++ b/src/conan_check_updates/main.py
@@ -45,8 +45,7 @@ class CheckUpdateResult:
 
 
 class ProgressCallback(Protocol):
-    def __call__(self, done: int, total: int):
-        ...
+    def __call__(self, done: int, total: int): ...
 
 
 async def check_updates(
@@ -119,11 +118,9 @@ def upgrade_conanfile(conanfile: Path, update_results: Sequence[CheckUpdateResul
 
         occurrences = content.count(str(result.ref))
         if occurrences < 1:
-            raise RuntimeError(f"Reference '{str(result.ref)}' not found in conanfile")
+            raise RuntimeError(f"Reference '{result.ref!s}' not found in conanfile")
         if occurrences > 1:
-            raise RuntimeError(
-                f"Multiple occurrences of reference '{str(result.ref)}' in conanfile"
-            )
+            raise RuntimeError(f"Multiple occurrences of reference '{result.ref!s}' in conanfile")
 
         # generate new reference with update version
         new_ref = replace(

--- a/tests/conanfile.py
+++ b/tests/conanfile.py
@@ -13,3 +13,10 @@ class Example(ConanFile):
     )
     tool_requires = "ninja/[^1.10]"
     generators = "cmake"
+
+    def requirements(self):
+        self.requires("openssl/3.2.0")
+        self.requires("nanodbc/2.13.0")
+        self.requires("ms-gsl/3.1.0")
+        self.tool_requires("cmake/3.27.7")
+        # self.requires("quill/3.6.0")

--- a/tests/conanfile.py.json
+++ b/tests/conanfile.py.json
@@ -1,0 +1,22 @@
+{
+    "requires": [
+      "boost/1.79.0",
+      "catch2/3.2.0",
+      "fmt/9.0.0",
+      "nlohmann_json/3.10.0"
+    ],
+    "tool_requires": [
+      "ninja/[^1.10]"
+    ],
+    "generators": [
+      "cmake"
+    ],
+    "requirements": [
+        "openssl/3.2.0",
+        "nanodbc/2.13.0",
+        "ms-gsl/3.1.0"
+    ],
+    "tool_requirements": [
+        "cmake/3.27.7"
+    ]
+  }

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -4,9 +4,14 @@ catch2/3.2.0
 # line comment
 fmt/9.0.0  # end of line comment
 nlohmann_json/3.10.0
+openssl/3.2.0
+nanodbc/2.13.0
+ms-gsl/3.1.0
+# quill/3.6.0
 
 [tool_requires]
 ninja/[^1.10]
+cmake/3.27.7
 
 [generators]
 cmake

--- a/tests/conanfile.txt.json
+++ b/tests/conanfile.txt.json
@@ -3,10 +3,14 @@
     "boost/1.79.0",
     "catch2/3.2.0",
     "fmt/9.0.0",
-    "nlohmann_json/3.10.0"
+    "nlohmann_json/3.10.0",
+    "openssl/3.2.0",
+    "nanodbc/2.13.0",
+    "ms-gsl/3.1.0"
   ],
   "tool_requires": [
-    "ninja/[^1.10]"
+    "ninja/[^1.10]",
+    "cmake/3.27.7"
   ],
   "generators": [
     "cmake"

--- a/tests/generate_output.py
+++ b/tests/generate_output.py
@@ -10,7 +10,7 @@ OUTPUT_DIR = HERE / "output"
 def run_and_save_output(name: str, cmd: str):
     print("Run", name)
     # pylint: disable=subprocess-run-check
-    proc = run(cmd, capture_output=True, shell=True, cwd=HERE)
+    proc = run(cmd, capture_output=True, shell=True, cwd=HERE, check=False)
     if proc.returncode != 0:
         raise RuntimeError(f"Error running '{cmd}':\n\n{proc.stderr.decode()}")
     (OUTPUT_DIR / f"{name}_stdout.txt").write_bytes(proc.stdout)

--- a/tests/test_conan_e2e.py
+++ b/tests/test_conan_e2e.py
@@ -28,10 +28,10 @@ def test_conan_version_fail():
         conan_version()
 
 
-@pytest.mark.parametrize("conanfile", ["conanfile.py", "conanfile.txt"])
-def test_inspect_requires_conanfile(conanfile):
-    expected = parse_requires_conanfile_json(HERE / "conanfile.json")
-    requires = inspect_requires_conanfile(HERE / conanfile)
+@pytest.mark.parametrize("conanfileext", ["py", "txt"])
+def test_inspect_requires_conanfile(conanfileext):
+    expected = parse_requires_conanfile_json(HERE / f"conanfile.{conanfileext}.json")
+    requires = inspect_requires_conanfile(HERE / f"conanfile.{conanfileext}")
     assert requires == expected
 
 


### PR DESCRIPTION
The reasoning was that in my projects, I frequently and primarily use self.requires in the requirements method of a conanfile.py, and those were not being checked at all by conan-check-updates, which seemed like a great project otherwise.

I've also added python 3.12 support and testing for it, updated pre-commit hooks to the latest and fixed some black and ruff warnings and errors.
Apologies if I've made a mess of anything, I've never really worked on a proper Python project before.